### PR TITLE
Refactor word sanitization and add test cases

### DIFF
--- a/src/linguaweb_api/routers/words/controller.py
+++ b/src/linguaweb_api/routers/words/controller.py
@@ -84,7 +84,7 @@ async def check_word(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Word ID not found.",
         )
-    return word_model.word.lower().strip() == word.lower().strip()
+    return _sanitize_word(word) == _sanitize_word(word_model.word)
 
 
 def download_audio(identifier: int, session: orm.Session, s3_client: s3.S3) -> bytes:
@@ -112,3 +112,18 @@ def download_audio(identifier: int, session: orm.Session, s3_client: s3.S3) -> b
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Audio not found.",
         ) from exception_info
+
+
+def _sanitize_word(word: str) -> str:
+    """Sanitizes a word.
+
+    Removes leading and trailing whitespace, converts to lowercase
+    and removes punctuation.
+
+    Args:
+        word: The word to sanitize.
+
+    Returns:
+        The sanitized word.
+    """
+    return word.lower().strip().strip(".,?!;:'\"")


### PR DESCRIPTION
This pull request refactors the word sanitization function in the words controller and adds test cases to ensure its correctness. The `_sanitize_word` function now removes leading and trailing whitespace, converts the word to lowercase, and removes punctuation. The test cases cover different variations of the word, including uppercase, lowercase, capitalized, and with leading/trailing spaces.